### PR TITLE
Addded two Dictionary display options

### DIFF
--- a/Assets/Plugins/Editor/Vexe/Drawers/API/Core/DictionaryDrawer.cs
+++ b/Assets/Plugins/Editor/Vexe/Drawers/API/Core/DictionaryDrawer.cs
@@ -249,7 +249,18 @@ namespace Vexe.Editor.Drawers
                         {
                             if (pairStr == null)
                                 pairStr = FormatPair(dKey, dValue);
-                            foldouts[entryKey] = gui.Foldout(pairStr, foldouts[entryKey], Layout.Auto);
+
+                            if (!_options.HideElementLabel)
+                            {
+                                foldouts[entryKey] = gui.Foldout(pairStr, foldouts[entryKey], Layout.Auto);
+                            }
+                            else
+                            {
+                                if (dValue != null && dValue.GetType().Namespace == "System")
+                                {
+                                    DrawValue(i, entryKey + 2);       
+                                }
+                            }
                         }
 
                         #if PROFILE
@@ -273,7 +284,11 @@ namespace Vexe.Editor.Drawers
                         else
                             using (gui.Indent())
                             {
-                                DrawKey(i, entryKey + 1);
+                                if (!_options.HideKeyNameField)
+                                {
+                                    DrawKey(i, entryKey + 1);
+                                }
+
                                 DrawValue(i, entryKey + 2);
                             }
                         #if PROFILE
@@ -484,6 +499,8 @@ namespace Vexe.Editor.Drawers
             public readonly bool Readonly;
             public readonly bool ForceExpand;
             public readonly bool HideHeader;
+            public readonly bool HideElementLabel;
+            public readonly bool HideKeyNameField;
             public readonly bool HorizontalPairs;
             public readonly bool Filter;
             public readonly bool AddToLast;
@@ -496,6 +513,8 @@ namespace Vexe.Editor.Drawers
                 Readonly           = options.HasFlag(Dict.Readonly);
                 ForceExpand        = options.HasFlag(Dict.ForceExpand);
                 HideHeader         = options.HasFlag(Dict.HideHeader);
+                HideElementLabel   = options.HasFlag(Dict.HideElementLabel);
+                HideKeyNameField = options.HasFlag(Dict.HideKeyNameField);
                 HorizontalPairs    = options.HasFlag(Dict.HorizontalPairs);
                 Filter             = options.HasFlag(Dict.Filter);
                 AddToLast          = options.HasFlag(Dict.AddToLast);

--- a/Assets/Plugins/Vexe/Runtime/Types/Attributes/API/DisplayAttribute.cs
+++ b/Assets/Plugins/Vexe/Runtime/Types/Attributes/API/DisplayAttribute.cs
@@ -135,6 +135,18 @@ namespace Vexe.Runtime.Types
         /// to be automatically allocated)
         /// </summary>
         ManualAlloc = 1 << 8,
+
+        /// <summary>
+        /// Hides the dictionary key name field. This means there is no option to rename the keys from the editor.
+        /// </summary>
+        HideKeyNameField= 1 << 9,
+
+        /// <summary>
+        /// Hides the elements Label. This means the key name and value type will not be shown.
+        /// Use it in conjuntion With HideKeyNameField to a minimal view.
+        /// (If your value is a class, You could add the key name to the value's ToString method to provide some visual feedback.)
+        /// </summary>
+        HideElementLabel= 1 << 10,
     }
 
     [Flags]

--- a/Assets/VFW Examples/Scripts/Serialization/SerializableDictExample.cs
+++ b/Assets/VFW Examples/Scripts/Serialization/SerializableDictExample.cs
@@ -8,6 +8,47 @@ public class SerializableDictExample : BaseBehaviour
 {
     public Lookup lookup = new Lookup();
 
+    [Button("AddItem")]
+    public string addItem;
+
+    [Display(Dict.HideElementLabel | Dict.HideKeyNameField | Dict.AddToLast)]
+    public Items items = new Items();
+
     [Serializable]
     public class Lookup : SerializableDictionary<string, GameObject> { }
+
+    [Serializable]
+    public class Items : SerializableDictionary<string, Item> 
+    {
+        
+    }
+
+    [Serializable]
+    public class Item
+    {
+        public string name;
+        public int durabilty;
+        public float price;
+        public bool isRare;
+
+        public Item(string _name)
+        {
+            name = _name;
+            durabilty = UnityEngine.Random.Range(0,9);
+            price = UnityEngine.Random.Range(0,9f);
+            isRare = false;
+
+        }
+
+        public override string ToString()
+        {
+            return name;
+        }
+    }
+
+    public void AddItem()
+    {
+        Item _newItem = new Item(addItem);
+        items.Add(_newItem.name, _newItem);
+    }
 }


### PR DESCRIPTION
Dict.HideElementLabel = hides the label for each dictionary element
Dict.HideKeyNameField = hides the "Key" field. This means theres no
option to rename the key from inspector.

Updated serializableDirectory example. [Pic](http://i.imgur.com/sGSKvVa.png)
