### PR TITLE
Added GetComponent Alternatives for Interfaces

### DIFF
--- a/Assets/Plugins/Vexe/Runtime/Library/Extensions/ComponentExtensions.cs
+++ b/Assets/Plugins/Vexe/Runtime/Library/Extensions/ComponentExtensions.cs
@@ -3,8 +3,45 @@ using UnityEngine;
 
 namespace Vexe.Runtime.Extensions
 {
-    public static class ComponentExtensions
+    public static class ComponentExtensions 
     {
+
+        // Works just like GetComponent<T>, except also works with interface types
+        public static T GetIComponent<T>(this Component c) where T : class 
+        {
+            return c.gameObject.GetIComponent<T>();
+        }
+
+        // Works just like GetComponentInChildren, except also works with interface types
+        public static T GetIComponentInChildren<T>(this Component c) where T : class 
+        {
+            return c.gameObject.GetIComponentInChildren<T>();
+        }
+
+        // Works just like GetComponentInParent, except also works with interface types
+        public static T GetIComponentInParent<T>(this Component c) where T : class 
+        {
+            return c.gameObject.GetIComponentInParent<T>();
+        }
+
+        // Works just like GetComponents, except also works with interface types
+        public static T[] GetIComponents<T>(this Component c) where T : class 
+        {
+            return c.gameObject.GetIComponents<T>();
+        }
+
+        // Works just like GetComponentInChildren, except also works with interface types
+        public static T[] GetIComponentsInChildren<T>(this Component c) where T : class 
+        {
+            return c.gameObject.GetIComponentsInChildren<T>();
+        }
+
+        // Works just like GetComponentsInParent, except also works with interface types
+        public static T[] GetIComponentsInParent<T>(this Component c) where T : class 
+        {
+            return c.gameObject.GetIComponentsInParent<T>();
+        }
+
         public static Component GetOrAddComponent(this Component c, Type componentType)
         {
             return c.gameObject.GetOrAddComponent(componentType);

--- a/Assets/Plugins/Vexe/Runtime/Library/Extensions/GameObjectExtensions.cs
+++ b/Assets/Plugins/Vexe/Runtime/Library/Extensions/GameObjectExtensions.cs
@@ -29,7 +29,43 @@ namespace Vexe.Runtime.Extensions
 			return parent == null ? string.Empty : parent.name;
 		}
 
-		public static bool HasComponent(this Transform source, Type componentType)
+        // Works just like GetComponent<T>, except also works with interface types
+	    public static T GetIComponent<T>(this GameObject go) where T : class 
+		{
+	        return go.GetComponent(typeof (T)) as T;
+	    }
+
+        // Works just like GetComponentInChildren, except also works with interface types
+	    public static T GetIComponentInChildren<T>(this GameObject go) where T : class 
+		{
+	        return go.GetComponentInChildren(typeof (T)) as T;
+	    }
+
+        // Works just like GetComponentInParent, except also works with interface types
+	    public static T GetIComponentInParent<T>(this GameObject go) where T : class 
+		{
+	        return go.GetComponentInParent(typeof (T)) as T;
+	    }
+
+        // Works just like GetComponents, except also works with interface types
+        public static T[] GetIComponents<T>(this GameObject go) where T : class 
+		{
+            return go.GetComponents(typeof(T)).OfType<T>().ToArray();
+        }
+
+        // Works just like GetComponentInChildren, except also works with interface types
+        public static T[] GetIComponentsInChildren<T>(this GameObject go) where T : class 
+		{
+            return go.GetComponentsInChildren(typeof(T)).OfType<T>().ToArray();
+        }
+
+        // Works just like GetComponentsInParent, except also works with interface types
+        public static T[] GetIComponentsInParent<T>(this GameObject go) where T : class 
+		{
+            return go.GetComponentsInParent(typeof(T)).OfType<T>().ToArray();
+        }
+
+        public static bool HasComponent(this Transform source, Type componentType)
 		{
 			return HasComponent(source.gameObject, componentType);
 		}
@@ -49,14 +85,14 @@ namespace Vexe.Runtime.Extensions
 			return source.GetComponent(componentName) != null;
 		}
 
-		public static bool HasComponent<T>(this Transform source) where T : Component
+		public static bool HasComponent<T>(this Transform source) where T : class
 		{
 			return HasComponent<T>(source.gameObject);
 		}
 
-		public static bool HasComponent<T>(this GameObject source) where T : Component
+		public static bool HasComponent<T>(this GameObject source) where T : class
 		{
-			return source.GetComponent<T>() != null;
+			return source.GetIComponent<T>() != null;
 		}
 
 		/// <summary>
@@ -223,7 +259,7 @@ namespace Vexe.Runtime.Extensions
 			return result == null ? go.AddComponent(componentType) : result;
 		}
 
-		public static T GetOrAddComponent<T>(this GameObject go) where T : Component
+		public static T GetOrAddComponent<T>(this GameObject go) where T : class
 		{
 			return GetOrAddComponent(go, typeof(T)) as T;
 		}


### PR DESCRIPTION
GetIComponent and its variants works just like their normal UnityEngine
counterparts (generic method, gets you components of a type), except that
they also work with any applicable type.

For example:

```
// Interface type
public interface IColorable 
{
       ...
}

// Implementor
public class Wall : MonoBehaviour, IColorable 
{
      // Implementation
}

// Other component looking for any Implementor
public class Paint : MonoBehaviour 
{
      void OnCollisionEnter(Collision col)
      {
           var colorable = col.collider.gameObject.GetIComponent<IColorable>().
           ...
      }
}
```

I have also changed a number of the similar functions in the GameObjectExtensions class to utilize it.
