### PR TITLE
Resolve Name Conflict

### DIFF
--- a/Assets/Plugins/Vexe/Runtime/Library/Extensions/UnityObjectExtensions.cs
+++ b/Assets/Plugins/Vexe/Runtime/Library/Extensions/UnityObjectExtensions.cs
@@ -5,17 +5,17 @@ namespace Vexe.Runtime.Extensions
 {
     public static class UnityObjectExtensions
     {
-        public static T Instantiate<T>(this T source, Vector3 pos, Quaternion rot) where T : UnityObject 
+        public static T Copy<T>(this T source, Vector3 pos, Quaternion rot) where T : UnityObject 
         {
             return UnityObject.Instantiate(source, pos, rot) as T;
         }
 
-        public static T Instantiate<T>(this T source, Vector3 pos) where T : UnityObject 
+        public static T Copy<T>(this T source, Vector3 pos) where T : UnityObject 
         {
             return UnityObject.Instantiate(source, pos, Quaternion.identity) as T;
         }
 
-        public static T Instantiate<T>(this T source) where T : UnityObject 
+        public static T Copy<T>(this T source) where T : UnityObject 
         {
             return UnityObject.Instantiate(source, Vector3.zero, Quaternion.identity) as T;
         }

--- a/Assets/Plugins/Vexe/Runtime/Library/Extensions/UnityObjectExtensions.cs
+++ b/Assets/Plugins/Vexe/Runtime/Library/Extensions/UnityObjectExtensions.cs
@@ -5,17 +5,17 @@ namespace Vexe.Runtime.Extensions
 {
     public static class UnityObjectExtensions
     {
-        public static T Copy<T>(this T source, Vector3 pos, Quaternion rot) where T : UnityObject 
+        public static T InstantiateNew<T>(this T source, Vector3 pos, Quaternion rot) where T : UnityObject 
         {
             return UnityObject.Instantiate(source, pos, rot) as T;
         }
 
-        public static T Copy<T>(this T source, Vector3 pos) where T : UnityObject 
+        public static T InstantiateNew<T>(this T source, Vector3 pos) where T : UnityObject 
         {
             return UnityObject.Instantiate(source, pos, Quaternion.identity) as T;
         }
 
-        public static T Copy<T>(this T source) where T : UnityObject 
+        public static T InstantiateNew<T>(this T source) where T : UnityObject 
         {
             return UnityObject.Instantiate(source, Vector3.zero, Quaternion.identity) as T;
         }

--- a/Assets/VFW Examples/Scripts/Attributes/ResourcePathExample.cs
+++ b/Assets/VFW Examples/Scripts/Attributes/ResourcePathExample.cs
@@ -22,7 +22,7 @@ public class ResourcePathExample : BaseBehaviour {
 	
 	[Comment("Enter any non-resource asset object here. It will provide a warning saying it doesn't save objects that aren't Resources.")]
 	[ResourcePath]
-	public string nonAssetPath;
+	public string nonResourcePath;
 	
 	[Comment("If a Resource is deleted, the value will reset to None (null).")]
 	[ResourcePath]


### PR DESCRIPTION
The Instantiate Extension functions were conflicting with the actual
static methods in the UnityEngine.Object class, making calling the
functions impossible.

Since the objects were already loaded in memory by the time the functions
are called. I renamed them to Copy instead (since that's basically what
the functions are doing at this point).
