### PR TITLE
Updated ResourcePathAttribute

### DIFF
--- a/Assets/Plugins/Vexe/Runtime/Types/Attributes/User/Others/ResourcePathAttribute.cs
+++ b/Assets/Plugins/Vexe/Runtime/Types/Attributes/User/Others/ResourcePathAttribute.cs
@@ -1,17 +1,23 @@
-﻿using UnityEngine;
-using System.Collections;
-using Vexe.Runtime.Types;
-using System;
+﻿using System;
+using UnityObject = UnityEngine.Object;
 
 namespace Vexe.Runtime.Types
 {
 
-[AttributeUsage(AttributeTargets.Field | AttributeTargets.Property | AttributeTargets.Parameter)]
-	public class ResourcePathAttribute : DrawnAttribute
-{
-	public ResourcePathAttribute()
-	{
-	}
-}
+    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property | AttributeTargets.Parameter)]
+	public class ResourcePathAttribute : DrawnAttribute 
+    {
+
+        public Type ResourceType { get; set; }
+
+        public ResourcePathAttribute(Type objectType = null) 
+        {
+	        if (objectType == null || !typeof(UnityObject).IsAssignableFrom(objectType))
+	            ResourceType = typeof(UnityObject);
+	        else
+	            ResourceType = objectType;
+	    }
+
+    }
 
 }

--- a/Assets/VFW Examples/Scripts/Attributes/ResourcePathExample.cs
+++ b/Assets/VFW Examples/Scripts/Attributes/ResourcePathExample.cs
@@ -4,14 +4,27 @@ using Vexe.Runtime.Types;
 
 public class ResourcePathExample : BaseBehaviour {
 
-	[Comment("Drag and drop a file here. Only objects inside the Resources folder will be accepted")]
+	[Comment("Enter any object here. It's resource path will be saved to the string.")]
 	[ResourcePath]
-	public string topLevelResource;
-
-	[Comment("Nested paths are also supported. Note that the file extension is note store so you can use Resources.Load() directly")]
+	public string generalResource;
+	
+	[Comment("Object types can be filtered by providing a type object in the attribute declaration.")]
+	[ResourcePath(typeof(AudioClip))]
+	public string audioClipResource;
+	
+	[Comment("Providing no type, or a non-asset type will default to the general Unity Object type.")]
+	[ResourcePath(typeof(string))]
+	public string attemptAtStringResource;
+	
+	[Comment("Enter any non-asset object here. It will provide a warning saying it doesn't save objects that aren't assets.")]
 	[ResourcePath]
-	public string nestedResource;
-
+	public string nonAssetPath;
+	
+	[Comment("Enter any non-resource asset object here. It will provide a warning saying it doesn't save objects that aren't Resources.")]
+	[ResourcePath]
+	public string nonAssetPath;
+	
+	[Comment("If a Resource is deleted, the value will reset to None (null).")]
 	[ResourcePath]
 	public string missingResource;
 


### PR DESCRIPTION
Changed the ResourcePathAttribute to show a more intuitive Object field
instead.

Changed the drawer to use Regex to detect whether the path is a valid
Resource path. It works much better and with less code than the previous
solution.

The "Clear Resource" clear button was reading "Clear Clear Resource",
fixed that.

With that addition, I also added a parameter to the attribute that allows
a filtering of exactly what kinds of Resources are accepted.

Instead of showing a dubious (missing resource) or (null) output. The
field displays a seperate debug line underneath the object field.

If a scene object is somehow dragged into the object field (it shouldn't),
it will say that only Assets are allowed.

If a non-Resource asset is dragged in, it will instead say that is is not
a Resource, and ask for it to be moved to a Resource Folder.

I also updated the Examples file accordingly.
