### PR TITLE
[EXAMPLES] Updated SceneTransition to Unity5.3 API

### DIFF
--- a/Assets/VFW Examples/Scripts/Other/SceneTransition.cs
+++ b/Assets/VFW Examples/Scripts/Other/SceneTransition.cs
@@ -1,4 +1,5 @@
 ﻿using UnityEngine;
+using UnityEngine.SceneManagement;
 
 namespace Vexe.Runtime.Types
 {
@@ -16,7 +17,7 @@ namespace Vexe.Runtime.Types
 		[Show]
 		public void LoadScene()
 		{
-			Application.LoadLevel(scene);
+			SceneManager.LoadScene(scene);
 		}
 	}
 }


### PR DESCRIPTION
Replaced deprecated Application.LoadLevel method with new Unity5.3 SceneManager equivalent in SceneTransition example script.
