### PR TITLE
Fix arguments at EditorGUI.InspectorTitlebar()

### DIFF
--- a/Assets/Plugins/Editor/Vexe/GUIs/RabbitGUI/RabbitGUI.cs
+++ b/Assets/Plugins/Editor/Vexe/GUIs/RabbitGUI/RabbitGUI.cs
@@ -827,7 +827,7 @@ namespace Vexe.Editor.GUIs
             Rect position;
             if (CanDrawControl(out position, data))
             {
-                return EditorGUI.InspectorTitlebar(position, foldout, target);
+                return EditorGUI.InspectorTitlebar(position, foldout, target, true);
             }
 
             return foldout;


### PR DESCRIPTION
According to the document, EditorGUI.InspectorTitlebar now seems to take 4 arguments, another one means "expandable or not".
http://docs.unity3d.com/ScriptReference/EditorGUI.InspectorTitlebar.html
